### PR TITLE
fix: fix for the R version schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,15 @@ desc.license = "MIT".to_string();
 ```rust
 use r_description::Version;
 
-let v1: Version = "1.2.3-alpha".parse().unwrap();
+// '-' and '.' are equivalent separators in R version strings
+let v1: Version = "2.5-1".parse().unwrap();
+let v2: Version = "2.5.1".parse().unwrap();
+assert_eq!(v1, v2);
+
+// Version strings can have more than three components
+let v1: Version = "1.2.3.9000".parse().unwrap();
 let v2: Version = "1.2.3".parse().unwrap();
-assert!(v1 < v2);
+assert!(v1 > v2);
 
 ```
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -2,17 +2,18 @@
 use std::cmp::Ordering;
 
 #[derive(Debug, PartialEq, Eq, std::hash::Hash, Clone)]
-/// Represents a version string like "1.2.3" or "1.2.3-alpha"
+/// Represents an R version string like "1.2.3" or "2.5-1".
+///
+/// R version strings consist of non-negative integers separated by `.` or `-`.
+/// Both separators are equivalent: `2.5-1` and `2.5.1` represent the same version.
+/// There is no concept of pre-release versions in R's versioning scheme.
 pub struct Version {
     /// Version components like [1, 2, 3]
     pub components: Vec<u32>,
-    /// Pre-release version like "alpha", "beta", etc.
-    pub pre_release: Option<String>, // Pre-release version like "alpha", "beta", etc.
 }
 
 impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Format the version string as "major.minor.patch" or "major.minor.patch-pre_release"
         f.write_str(
             &self
                 .components
@@ -20,25 +21,19 @@ impl std::fmt::Display for Version {
                 .map(|c| c.to_string())
                 .collect::<Vec<_>>()
                 .join("."),
-        )?;
-        if let Some(pre_release) = &self.pre_release {
-            f.write_str("-")?;
-            f.write_str(pre_release)?;
-        }
-        Ok(())
+        )
     }
 }
 
 impl Version {
     /// Create a new version
-    pub fn new(major: u32, minor: u32, patch: Option<u32>, pre_release: Option<&str>) -> Self {
+    pub fn new(major: u32, minor: u32, patch: Option<u32>) -> Self {
         Self {
             components: if let Some(patch) = patch {
                 vec![major, minor, patch]
             } else {
                 vec![major, minor]
             },
-            pre_release: pre_release.map(|s| s.to_string()),
         }
     }
 }
@@ -47,59 +42,39 @@ impl std::str::FromStr for Version {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Split the version string by '.' and '-' to get major, minor, patch, and pre-release
-        let mut parts = s.splitn(2, '-');
-        let version = parts.next().ok_or(format!("Invalid version string: {s}"))?;
-        let pre_release = parts.next().map(|s| s.to_string());
-
-        let components = version
-            .split('.')
+        // Both '.' and '-' are valid separators in R version strings and are equivalent.
+        // e.g. "2.5-1" == "2.5.1"
+        let components = s
+            .split(|c| c == '.' || c == '-')
             .map(|part| {
                 part.parse()
                     .map_err(|_| format!("Invalid version component: {s}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Self {
-            components,
-            pre_release,
-        })
+        if components.len() < 2 {
+            return Err(format!("Invalid version string: {s}"));
+        }
+
+        Ok(Self { components })
     }
 }
 
 impl Ord for Version {
     fn cmp(&self, other: &Self) -> Ordering {
-        // Compare components in order, and then compare pre-release tags
         for (a, b) in self.components.iter().zip(other.components.iter()) {
             match a.cmp(b) {
                 Ordering::Equal => continue,
                 ordering => return ordering,
             }
         }
-        if self.components.len() < other.components.len() {
-            Ordering::Less
-        } else if self.components.len() > other.components.len() {
-            Ordering::Greater
-        } else {
-            self.compare_pre_release(other)
-        }
+        self.components.len().cmp(&other.components.len())
     }
 }
 
 impl PartialOrd for Version {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
-    }
-}
-
-impl Version {
-    fn compare_pre_release(&self, other: &Self) -> Ordering {
-        match (&self.pre_release, &other.pre_release) {
-            (None, None) => Ordering::Equal,
-            (None, Some(_)) => Ordering::Greater,
-            (Some(_), None) => Ordering::Less,
-            (Some(a), Some(b)) => a.cmp(b),
-        }
     }
 }
 
@@ -110,16 +85,16 @@ mod tests {
 
     #[test]
     fn test_version_from_str() {
-        use std::str::FromStr;
-
         let version = Version::from_str("1.2.3").unwrap();
-        assert_eq!(version, Version::new(1, 2, Some(3), None));
+        assert_eq!(version, Version::new(1, 2, Some(3)));
 
-        let version = Version::from_str("1.2.3-alpha").unwrap();
-        assert_eq!(version, Version::new(1, 2, Some(3), Some("alpha")));
+        // '-' and '.' are equivalent separators in R
+        let version = Version::from_str("2.5-1").unwrap();
+        assert_eq!(version.components, vec![2, 5, 1]);
 
-        let version = Version::from_str("1.2.3-beta").unwrap();
-        assert_eq!(version, Version::new(1, 2, Some(3), Some("beta")));
+        // Development versions use a 4th numeric component
+        let version = Version::from_str("1.2.3.9000").unwrap();
+        assert_eq!(version.components, vec![1, 2, 3, 9000]);
     }
 
     #[test]
@@ -134,18 +109,36 @@ mod tests {
         let v2 = Version::from_str("1.2.4").unwrap();
         assert_eq!(v1.cmp(&v2), Ordering::Less);
 
-        let v1 = Version::from_str("1.2.3").unwrap();
-        let v2 = Version::from_str("1.2.3-alpha").unwrap();
+        // '-' and '.' are equivalent: "2.5-1" == "2.5.1"
+        let v1 = Version::from_str("2.5-1").unwrap();
+        let v2 = Version::from_str("2.5.1").unwrap();
+        assert_eq!(v1.cmp(&v2), Ordering::Equal);
+
+        // Versions can have more than three components
+        let v1 = Version::from_str("1.2.3.9000").unwrap();
+        let v2 = Version::from_str("1.2.3").unwrap();
         assert_eq!(v1.cmp(&v2), Ordering::Greater);
 
-        let v1 = Version::from_str("1.2.3-alpha").unwrap();
-        let v2 = Version::from_str("1.2.3-beta").unwrap();
+        let v1 = Version::from_str("1.2.3.9000").unwrap();
+        let v2 = Version::from_str("1.2.4").unwrap();
         assert_eq!(v1.cmp(&v2), Ordering::Less);
+    }
+
+    #[test]
+    fn test_version_display() {
+        // Display normalizes to '.' separator
+        let version = Version::from_str("1.2.3").unwrap();
+        assert_eq!(version.to_string(), "1.2.3");
+
+        let version = Version::from_str("2.5-1").unwrap();
+        assert_eq!(version.to_string(), "2.5.1");
     }
 
     #[test]
     fn test_version_invalid() {
         assert!(Version::from_str("a").is_err());
-        assert!(Version::from_str("a1-b").is_err());
+        assert!(Version::from_str("1.a.3").is_err());
+        // Single component is not a valid R package version
+        assert!(Version::from_str("1").is_err());
     }
 }


### PR DESCRIPTION
My understanding is that in R package's version schema, hyphens and periods are equivalent, and there is no way to represent a pre-release version like SemVer.
Versions must be represented by two or more period-separated numbers.