### PR TITLE
fix: Accept R-style strict dependency operators

### DIFF
--- a/src/lossless.rs
+++ b/src/lossless.rs
@@ -1304,6 +1304,24 @@ pub mod relations {
                     "0.20.21".parse().unwrap()
                 ))
             );
+
+            let input = "xml2 (> 1.0.0)";
+            let parsed: Relations = input.parse().unwrap();
+            assert_eq!(parsed.to_string(), input);
+            let relation = parsed.relations().next().unwrap();
+            assert_eq!(
+                relation.version(),
+                Some((VersionConstraint::GreaterThan, "1.0.0".parse().unwrap()))
+            );
+
+            let input = "xml2 (< 2.0.0)";
+            let parsed: Relations = input.parse().unwrap();
+            assert_eq!(parsed.to_string(), input);
+            let relation = parsed.relations().next().unwrap();
+            assert_eq!(
+                relation.version(),
+                Some((VersionConstraint::LessThan, "2.0.0".parse().unwrap()))
+            );
         }
 
         #[test]

--- a/src/lossy.rs
+++ b/src/lossy.rs
@@ -558,6 +558,22 @@ License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
                 "0.20.21".parse().unwrap()
             ))
         );
+
+        let parsed: Relations = "xml2 (> 1.0.0)".parse().unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].name, "xml2");
+        assert_eq!(
+            parsed[0].version,
+            Some((VersionConstraint::GreaterThan, "1.0.0".parse().unwrap()))
+        );
+
+        let parsed: Relations = "xml2 (< 2.0.0)".parse().unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].name, "xml2");
+        assert_eq!(
+            parsed[0].version,
+            Some((VersionConstraint::LessThan, "2.0.0".parse().unwrap()))
+        );
     }
 
     #[test]

--- a/src/relations.rs
+++ b/src/relations.rs
@@ -27,8 +27,8 @@ impl std::str::FromStr for VersionConstraint {
             ">=" => Ok(VersionConstraint::GreaterThanEqual),
             "<=" => Ok(VersionConstraint::LessThanEqual),
             "=" => Ok(VersionConstraint::Equal),
-            ">>" => Ok(VersionConstraint::GreaterThan),
-            "<<" => Ok(VersionConstraint::LessThan),
+            ">" | ">>" => Ok(VersionConstraint::GreaterThan),
+            "<" | "<<" => Ok(VersionConstraint::LessThan),
             _ => Err(format!("Invalid version constraint: {s}")),
         }
     }


### PR DESCRIPTION
Hi, If you look at the PACKAGES index exposed by cran or at most major packages DESCRIPTIONS you will see the relations strings they have rarely conform to the Debian spec of using <<.